### PR TITLE
Gcloud version change and update git cmds to push back helm changes for custom action for GCP

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-    - uses: google-github-actions/setup-gcloud@v1
+    - uses: google-github-actions/setup-gcloud@v2
     
     - id: auth
       uses: google-github-actions/auth@v1

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,8 @@ runs:
   steps:
     - uses: actions/checkout@v4
     - uses: google-github-actions/setup-gcloud@v2
+      with:
+        version: '455.0.0'
     
     - id: auth
       uses: google-github-actions/auth@v1

--- a/action.yml
+++ b/action.yml
@@ -136,7 +136,11 @@ runs:
       shell: bash
 
     - id: push-back
-      uses: stefanzweifel/git-auto-commit-action@v5
-      with:
-        commit_message: Apply automatic changes to Update image repository in Helm values
-        file_pattern: ${{ inputs.helm_values_path }}
+      run: |-
+        git config --global user.email "github-action-bot@polygon.technology.com"
+        git config --global user.name "github-actions[bot]"
+        git pull
+        git add ${{ inputs.helm_values_path }}
+        git commit -m "Apply automatic changes to Update image repository in Helm values"
+        git push -u origin ${{ github.ref_name }}
+      shell: bash


### PR DESCRIPTION
# Pull Request Template

## Description

- Latest version of gcloud was not working with binary attestation of images. Fixed this issue with gcloud version '455.0.0'.

- Updated the git commands to push back helm changes for custom action for GCP build pipeline.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?



- [x] Tested from webflow apis repo: https://github.com/maticnetwork/polygon-webflow-apis/actions/runs/7408272299/job/20156145257


## Checklist:

Before you submit your pull request, please make sure you have completed the following:

- [x] I have followed the [contributing guidelines](CONTRIBUTING.md).
- [x] My code follows the style guidelines of this project and I have run `lint` to ensure the code style is valid
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if appropriate):

Include any screenshots that will help explain your changes.

## Additional context

Add any other context about the pull request here.
