### PR TITLE
Fix for deployment using github secrets for nextjs

### DIFF
--- a/.github/workflows/ecs_deploy_docker_taskdef.yaml
+++ b/.github/workflows/ecs_deploy_docker_taskdef.yaml
@@ -36,7 +36,11 @@ on:
         required: false
         default: "staging"
         type: string
-      
+    secrets:
+      build_params_gh_secret_keys:
+        required: false
+        description: "Pass github secrets in json format for supporting docker build"
+
 
 jobs:
   deploy_workflow:
@@ -63,6 +67,19 @@ jobs:
         with:
           fetch-depth: 0
           path: ./code
+
+      - name: Set up secrets
+        run: |
+          if [ -n "${{ secrets.build_params_gh_secret_keys }}" ]; then
+            echo "${{ secrets.build_params_gh_secret_keys }}" > secrets.json
+          fi
+
+      - name: Parse secrets and set environment variables
+        run: |
+          if [ -f secrets.json ]; then
+            echo "Setting environment variables from JSON..."
+            jq -r 'to_entries | .[] | "\(.key)=\(.value)"' secrets.json >> $GITHUB_ENV
+          fi
 
       - name: Set variables
         run: |

--- a/.github/workflows/npm_build_deploy_default.yaml
+++ b/.github/workflows/npm_build_deploy_default.yaml
@@ -23,7 +23,11 @@ on:
       environment:
         required: false
         default: "staging"
-        type: string      
+        type: string
+    secrets:
+      build_params_gh_secret_keys:
+        required: false
+        description: "Pass github secrets in json format for supporting docker build"
 
 jobs:
   deploy_workflow:
@@ -52,6 +56,19 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 20.9.0
+        
+      - name: Set up secrets
+        run: |
+          if [ -n "${{ secrets.build_params_gh_secret_keys }}" ]; then
+            echo "${{ secrets.build_params_gh_secret_keys }}" > secrets.json
+          fi
+
+      - name: Parse secrets and set environment variables
+        run: |
+          if [ -f secrets.json ]; then
+            echo "Setting environment variables from JSON..."
+            jq -r 'to_entries | .[] | "\(.key)=\(.value)"' secrets.json >> $GITHUB_ENV
+          fi
 
       - name: INSTALL
         run: npm install

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/*
 *.pyc
+.idea


### PR DESCRIPTION
# Pull Request Template
Fix for deployment using github secrets for nextjs
Secret can be passed in json format e.g. 
```github
secrets:
      build_params_gh_secret_keys: '{\"NEXT_PUBLIC_PROJECT_ID\":\"${{ secrets.NEXT_PUBLIC_PROJECT_ID }}\"}'
```

## Description

[SPEC-269](https://polygon.atlassian.net/browse/SPEC-269)
The secrets need to be passed and accessed dynamically. Now secrets can be passed if required and github secrets can be used for passing to docker build step. This helps fix the nextjs issue where secrets are required at build time.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Before you submit your pull request, please make sure you have completed the following:

- [ ] My code follows the style guidelines of this project and I have run `lint` to ensure the code style is valid
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Additional context

Add any other context about the pull request here.

[SPEC-269]: https://polygon.atlassian.net/browse/SPEC-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ