### PR TITLE
chore(npm-release): remove workflow-level build step

### DIFF
--- a/.github/workflows/apps-npm-release.yml
+++ b/.github/workflows/apps-npm-release.yml
@@ -86,20 +86,6 @@ jobs:
       # the lockfile is structurally stale at the release-PR merge commit.
       - run: pnpm install --no-frozen-lockfile --config.link-workspace-packages=true
 
-      # Safety net for consumers that forgot a `prepublishOnly` (or
-      # `prepack`) script in their published package's package.json.
-      # `dist/` is typically gitignored, so without a build hook the
-      # publish ships an empty tarball (just package.json + license +
-      # README) — silently broken on first install. matic.js@3.9.9 went
-      # out this way; consumers got no compiled code and the package
-      # had to be deprecated and republished as 3.9.10. Building here
-      # unconditionally guards every consumer against the same trap.
-      # `--if-present` skips packages without a `build` script (services,
-      # internal-only utilities). Packages that already have a publish
-      # lifecycle hook will run their own build again — idempotent
-      # against a clean tree.
-      - run: pnpm -r run --if-present build
-
       - uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           title: 'changesets: Release / Deploy'
@@ -178,11 +164,6 @@ jobs:
           SNAPSHOT_TAG: ${{ inputs.snapshot_tag }}
         shell: bash
         run: pnpm exec changeset version --snapshot "$SNAPSHOT_TAG"
-
-      # See the equivalent step in the `release` job: a snapshot
-      # publish is just as exposed to the missing-`prepublishOnly`
-      # trap as a real release, so apply the same workflow-level guard.
-      - run: pnpm -r run --if-present build
 
       - name: Publish snapshot
         # `--snapshot` is intentionally NOT passed to `changeset publish`:


### PR DESCRIPTION
## Summary

Drop `pnpm -r run --if-present build` from both the `release` and `snapshot` jobs in `apps-npm-release.yml`. Building every workspace package on every release is unacceptably slow in large monorepos — and unnecessary, since `changeset publish` already runs each published package's `prepublishOnly` / `prepack` lifecycle hook, which only builds what's actually being published.

This reverts the safety net added in #40. The trade-off there was: catch consumers who forget `prepublishOnly` (so an empty tarball ships) at the cost of building every package every time. In practice the cost is unbounded — large monorepos pay it on every release for every package, even when only one is being published. The right place to enforce a build is the package's own lifecycle hook.

## Verification

Swept every consumer of `apps-npm-release.yml@main` across 0xPolygon / AggLayer / maticnetwork (8 repos: apps-team-packages, apps-team-ts-template, apps-team-workflows, gas-station, lst-api, matic.js, pos-airdrop, proof-generation-api). Every publishable package on the team — all 10 of them — already has a `prepublishOnly` script. No package relies on the workflow-level guard.

## Test plan

- [ ] Land in `pipelines`
- [ ] Trigger an npm release in a consuming repo (e.g. `apps-team-packages`) and confirm the runtime drops while the published tarball still contains compiled output
- [ ] Confirm snapshot publishes still work end-to-end