### PR TITLE
feat(e2e): add apps-e2e shared workflow + composite actions

### DIFF
--- a/.github/actions/e2e-cold-start/action.yml
+++ b/.github/actions/e2e-cold-start/action.yml
@@ -1,0 +1,42 @@
+name: E2E cold-start
+description: >
+  Bring up a kurtosis-pos devnet from source. Installs the kurtosis CLI,
+  starts the engine, clones kurtosis-pos at the requested ref, scales EL
+  resource limits down to fit a 2-vCPU / 7-GB ubuntu-latest runner, and
+  runs the enclave from the consumer's args file.
+
+  This is the escape hatch for iterating on a kurtosis-pos branch that
+  hasn't been snapshotted yet. ~10 minute wall-time vs the ~30 second
+  snapshot path; consumers default to the snapshot and reach for cold
+  start only when they need an unpublished kurtosis-pos commit.
+
+inputs:
+  kurtosis_pos_ref:
+    description: >
+      Git ref of 0xPolygon/kurtosis-pos to clone (branch, tag, or SHA).
+    required: false
+    default: main
+  args_file:
+    description: >
+      Path to the kurtosis args file in the consumer's checkout (relative
+      to GITHUB_WORKSPACE). Each consumer ships its own — the args dictate
+      L1 backend, contract deployments, and chain IDs that the enclave
+      brings up.
+    required: false
+    default: kurtosis-params.yml
+  work_dir:
+    description: >
+      Scratch dir for the kurtosis-pos clone. Default `/tmp/kurtosis-pos`.
+    required: false
+    default: /tmp/kurtosis-pos
+
+runs:
+  using: composite
+  steps:
+    - name: Cold-start kurtosis-pos enclave
+      shell: bash
+      env:
+        KURTOSIS_POS_REF: ${{ inputs.kurtosis_pos_ref }}
+        ARGS_FILE: ${{ inputs.args_file }}
+        WORK_DIR: ${{ inputs.work_dir }}
+      run: bash "${GITHUB_ACTION_PATH}/cold-start.sh"

--- a/.github/actions/e2e-cold-start/cold-start.sh
+++ b/.github/actions/e2e-cold-start/cold-start.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Cold-start a kurtosis-pos devnet from source.
+#
+# Used by consumers who need to test against an unpublished kurtosis-pos
+# branch (the snapshot publisher only refreshes weekly + only off `main`).
+# Total wall-time: ~10 minutes vs ~30s for the snapshot path. The snapshot
+# is the default; this is the escape hatch.
+#
+# # Inputs (env vars, set by the composite action with documented defaults)
+#
+#   KURTOSIS_POS_REF   git ref of 0xPolygon/kurtosis-pos to clone.
+#   ARGS_FILE          kurtosis args file in the consumer's checkout
+#                      (resolved against GITHUB_WORKSPACE).
+#   WORK_DIR           scratch dir for the clone.
+#
+# # After this script exits 0
+#
+# `kurtosis enclave inspect pos` reports RUNNING. Downstream steps reach
+# the chain via the kurtosis-emitted env vars (each consumer's e2e suite
+# already has its own kurtosis adapter — this script doesn't export
+# anything to GITHUB_ENV).
+
+set -euo pipefail
+
+KURTOSIS_POS_REF="${KURTOSIS_POS_REF:-main}"
+ARGS_FILE="${ARGS_FILE:-kurtosis-params.yml}"
+WORK_DIR="${WORK_DIR:-/tmp/kurtosis-pos}"
+
+REPO_ROOT="${GITHUB_WORKSPACE:-$PWD}"
+ARGS_FILE_ABS="${REPO_ROOT}/${ARGS_FILE}"
+if [ ! -f "$ARGS_FILE_ABS" ]; then
+  echo "[e2e-cold-start] ERROR: args file not found at ${ARGS_FILE_ABS}" >&2
+  echo "[e2e-cold-start] Pass the path relative to your repo root via the action's args_file input." >&2
+  exit 1
+fi
+
+##############################################################################
+# 1. Install kurtosis CLI
+##############################################################################
+if command -v kurtosis >/dev/null 2>&1; then
+  echo "[e2e-cold-start] kurtosis already installed: $(kurtosis version | head -n1)"
+else
+  echo "[e2e-cold-start] installing kurtosis-cli via apt"
+  echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" \
+    | sudo tee /etc/apt/sources.list.d/kurtosis.list >/dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y --no-install-recommends kurtosis-cli
+  # Kurtosis prompts for analytics consent on first interactive use; disable
+  # explicitly so the CLI never blocks on stdin in a non-TTY shell.
+  kurtosis analytics disable
+fi
+
+##############################################################################
+# 2. Start the kurtosis engine
+##############################################################################
+echo "[e2e-cold-start] starting kurtosis engine"
+kurtosis engine start
+
+##############################################################################
+# 3. Clone kurtosis-pos and run the enclave
+##############################################################################
+if kurtosis enclave inspect pos 2>/dev/null | grep -q RUNNING; then
+  echo "[e2e-cold-start] enclave 'pos' already running"
+  exit 0
+fi
+
+if [ ! -d "$WORK_DIR" ]; then
+  echo "[e2e-cold-start] cloning kurtosis-pos@${KURTOSIS_POS_REF} into ${WORK_DIR}"
+  git clone --depth 1 --branch "$KURTOSIS_POS_REF" \
+    https://github.com/0xPolygon/kurtosis-pos.git "$WORK_DIR"
+fi
+
+# kurtosis-pos hardcodes `MAX_CPU = 4000, MAX_MEM = 16384` for EL services,
+# which exceeds what private-repo GitHub-hosted runners provide (2 vCPU,
+# 7 GB). Scale down in place so the enclave fits on ubuntu-latest. On a
+# developer machine with more headroom this rewrite is a no-op from the
+# suite's perspective — the services just use less of the available
+# capacity. Remove once kurtosis-pos exposes these as inputs.
+#
+# This patch is brittle by nature: it depends on the file path and the
+# variable names. `kurtosis_pos_ref` is consumer-overridable, so an
+# unexpected ref could rename either and make the sed a silent no-op —
+# the enclave would then request 16 GB and the runner OOM-kills it with a
+# confusing failure. Verify the override actually landed and fail loud if
+# not, so the cause is unambiguous.
+shared_star="$WORK_DIR/src/el/shared.star"
+if [ ! -f "$shared_star" ]; then
+  echo "[e2e-cold-start] ERROR: expected ${shared_star} not found — kurtosis-pos@${KURTOSIS_POS_REF} may have moved the EL resource config. Update cold-start.sh for this ref." >&2
+  exit 1
+fi
+sed -i.bak -E \
+  -e 's/^MAX_CPU = [0-9]+.*/MAX_CPU = 1800  # CI override (ubuntu-latest 2-vCPU private-repo runner)/' \
+  -e 's/^MAX_MEM = [0-9]+.*/MAX_MEM = 4096  # CI override (ubuntu-latest 7-GB private-repo runner)/' \
+  "$shared_star"
+rm -f "${shared_star}.bak"
+# Confirm both overrides applied — grep for the marker comment the sed adds.
+# Two matches expected (MAX_CPU + MAX_MEM); anything less means a var was
+# renamed and we'd silently run at full resource request.
+override_count="$(grep -c 'CI override (ubuntu-latest' "$shared_star" || true)"
+if [ "$override_count" -ne 2 ]; then
+  echo "[e2e-cold-start] ERROR: EL resource scale-down did not apply (${override_count}/2 markers found in ${shared_star}). kurtosis-pos@${KURTOSIS_POS_REF} likely renamed MAX_CPU/MAX_MEM — the runner would OOM. Update the sed patterns for this ref." >&2
+  exit 1
+fi
+
+echo "[e2e-cold-start] running enclave 'pos' (this takes ~5–10m)"
+( cd "$WORK_DIR" && kurtosis run --enclave pos --args-file "$ARGS_FILE_ABS" . )
+
+# Export the enclave name so the consumer's e2e suite can locate it via the
+# kurtosis CLI in cold-start mode (symmetric with snapshot mode exporting
+# E2E_SNAPSHOT_ADDRESSES_JSON). Lets a consumer write a single env-driven
+# adapter instead of hardcoding the enclave name per mode.
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "E2E_KURTOSIS_ENCLAVE=pos" >> "$GITHUB_ENV"
+fi
+
+echo "[e2e-cold-start] ready"

--- a/.github/actions/e2e-dump/action.yml
+++ b/.github/actions/e2e-dump/action.yml
@@ -1,0 +1,40 @@
+name: E2E devnet dump
+description: >
+  Capture devnet state into /tmp/devnet-dump for post-mortem after an e2e
+  failure. Snapshot mode dumps the docker-compose stack's ps + logs and the
+  compose file; cold-start mode dumps the kurtosis enclave. Best-effort —
+  individual failures are swallowed so a half-restored run still yields
+  whatever artefacts it can.
+
+  Bundled as a composite (not a reusable-workflow inline step or a
+  .github/scripts/ helper) so the shell logic is locally runnable AND
+  reachable when apps-e2e.yml runs in a consumer's checkout — a raw script
+  under .github/scripts/ is not on disk cross-repo; ${{ github.action_path }}
+  is.
+
+inputs:
+  use_snapshot:
+    description: '"1" for snapshot mode (compose dump), "0" for cold-start (enclave dump).'
+    required: true
+  compose_file:
+    description: >
+      Snapshot mode: path to the restored docker-compose.yaml (the restore
+      composite's compose_file_path output). May be empty if the restore
+      failed before writing it — the dump guards for that.
+    required: false
+    default: ''
+  enclave:
+    description: 'Cold-start mode: kurtosis enclave name to dump.'
+    required: false
+    default: pos
+
+runs:
+  using: composite
+  steps:
+    - name: Dump devnet state
+      shell: bash
+      env:
+        E2E_USE_SNAPSHOT: ${{ inputs.use_snapshot }}
+        COMPOSE_FILE: ${{ inputs.compose_file }}
+        E2E_KURTOSIS_ENCLAVE: ${{ inputs.enclave }}
+      run: bash "${GITHUB_ACTION_PATH}/dump-devnet.sh"

--- a/.github/actions/e2e-dump/dump-devnet.sh
+++ b/.github/actions/e2e-dump/dump-devnet.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Capture devnet state into /tmp/devnet-dump for post-mortem after an e2e
+# failure. Invoked by the e2e-dump composite action. Two modes, picked by
+# E2E_USE_SNAPSHOT:
+#
+#   - Snapshot mode (=1): dump the docker-compose stack's `ps` + `logs` and
+#     copy the compose file itself. COMPOSE_FILE is the path the restore
+#     composite emitted; it may be unset/absent if the restore failed before
+#     writing it, so every step is guarded.
+#   - Cold-start mode (=0): dump the kurtosis enclave named by
+#     E2E_KURTOSIS_ENCLAVE (default `pos`).
+#
+# Best-effort throughout: a half-restored run should still yield whatever
+# artefacts it can, so individual failures are swallowed with `|| true`
+# rather than aborting the dump.
+#
+# Environment (set by action.yml):
+#   E2E_USE_SNAPSHOT      "1" for snapshot mode, "0" for cold-start.
+#   COMPOSE_FILE          snapshot mode: path to the restored docker-compose.
+#   E2E_KURTOSIS_ENCLAVE  cold-start mode: enclave name (default `pos`).
+
+set -euo pipefail
+
+DUMP_DIR="/tmp/devnet-dump"
+mkdir -p "$DUMP_DIR"
+
+if [ "${E2E_USE_SNAPSHOT:-1}" = "1" ]; then
+  compose_file="${COMPOSE_FILE:-}"
+  if [ -n "$compose_file" ] && [ -f "$compose_file" ]; then
+    docker compose --file "$compose_file" ps > "${DUMP_DIR}/compose-ps.txt" 2>&1 || true
+    docker compose --file "$compose_file" logs --no-color > "${DUMP_DIR}/compose-logs.txt" 2>&1 || true
+    cp "$compose_file" "${DUMP_DIR}/docker-compose.yaml" || true
+  else
+    echo "[dump-devnet] no compose file at '${compose_file:-<unset>}' — restore likely failed before writing it" >&2
+  fi
+else
+  enclave="${E2E_KURTOSIS_ENCLAVE:-pos}"
+  kurtosis enclave dump "$enclave" "${DUMP_DIR}/${enclave}" || true
+fi

--- a/.github/actions/e2e-snapshot-restore/action.yml
+++ b/.github/actions/e2e-snapshot-restore/action.yml
@@ -1,0 +1,88 @@
+name: E2E snapshot restore
+description: >
+  Restore a kurtosis-pos devnet from a published snapshot image. Pulls the image
+  from GHCR, extracts volumes + docker-compose + addresses sidecar, patches the
+  pos-anvil host-port mapping, brings the devnet up, and replays the captured
+  anvil state. Exports E2E_SNAPSHOT_ADDRESSES_JSON to GITHUB_ENV so consumer
+  steps inherit the path to the addresses sidecar.
+
+inputs:
+  image:
+    description: >
+      Snapshot image reference (full registry/repo:tag). Default points at the
+      lst-api-published snapshot. Pin to a SHA tag (e.g. ":22c449550213") to
+      lock to a specific kurtosis-pos commit.
+    required: false
+    default: ghcr.io/0xpolygon/lst-api-e2e-snapshot:latest
+  kurtosis_pos_ref:
+    description: >
+      Git ref of 0xPolygon/kurtosis-pos to clone for the upstream extract.sh /
+      restore.sh helpers. Should match the ref used to build the snapshot —
+      the extract/restore scripts are tightly paired with their snapshot
+      contents. Default 'main' tracks the snapshot publisher's default.
+    required: false
+    default: main
+  out_dir:
+    description: >
+      Directory the snapshot is extracted into, relative to the consumer's
+      checkout root. Default './tmp/e2e-snapshot' avoids clobbering anything
+      else under ./tmp.
+    required: false
+    default: ./tmp/e2e-snapshot
+  registry:
+    description: >
+      Container registry to authenticate against. Default 'ghcr.io'. Override
+      only when the snapshot image lives elsewhere.
+    required: false
+    default: ghcr.io
+  registry_username:
+    description: >
+      Username for the registry login. Defaults to the workflow actor; override
+      when calling with a service account or PAT.
+    required: false
+    default: ${{ github.actor }}
+  registry_password:
+    description: >
+      Token for the registry login. Defaults to GITHUB_TOKEN, which works for
+      same-org GHCR pulls when the calling workflow grants `packages: read`.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  addresses_json_path:
+    description: Absolute path to the extracted addresses sidecar JSON.
+    value: ${{ steps.restore.outputs.addresses_json_path }}
+  compose_file_path:
+    description: Absolute path to the bundled docker-compose.yaml.
+    value: ${{ steps.restore.outputs.compose_file_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to container registry
+      shell: bash
+      env:
+        REGISTRY: ${{ inputs.registry }}
+        REGISTRY_USERNAME: ${{ inputs.registry_username }}
+        REGISTRY_PASSWORD: ${{ inputs.registry_password }}
+      run: echo "$REGISTRY_PASSWORD" | docker login "$REGISTRY" -u "$REGISTRY_USERNAME" --password-stdin
+
+    - name: Restore devnet from snapshot
+      id: restore
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+        KURTOSIS_POS_REF: ${{ inputs.kurtosis_pos_ref }}
+        OUT_DIR: ${{ inputs.out_dir }}
+      run: bash "${GITHUB_ACTION_PATH}/restore.sh"
+
+    - name: Export snapshot addresses path to GITHUB_ENV
+      shell: bash
+      env:
+        ADDRS_PATH: ${{ steps.restore.outputs.addresses_json_path }}
+      run: |
+        # The consuming repo's e2e suite reads this env var to switch from the
+        # kurtosis CLI path to the sidecar JSON path. Writing to GITHUB_ENV
+        # propagates it to every subsequent step in the calling job without
+        # the consumer having to know the magic name.
+        echo "E2E_SNAPSHOT_ADDRESSES_JSON=${ADDRS_PATH}" >> "$GITHUB_ENV"

--- a/.github/actions/e2e-snapshot-restore/restore.sh
+++ b/.github/actions/e2e-snapshot-restore/restore.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+#
+# Restore a kurtosis-pos devnet from a snapshot image produced by
+# lst-api's `build-e2e-snapshot.sh`.
+#
+# # Why this script lives here
+#
+# The publisher (`build-e2e-snapshot.sh`) currently lives in lst-api but the
+# consumer-side restore is identical for every consumer (matic.js, future
+# proof-generation-api integration tests). Centralising the restore here
+# means a bug fix lands in one place instead of N copies that drift.
+#
+# # How it's invoked
+#
+# Via the `e2e-snapshot-restore` composite action's `action.yml`. The action
+# logs in to the registry, sets IMAGE / KURTOSIS_POS_REF / OUT_DIR via env,
+# then runs this script. The script writes its output paths to
+# $GITHUB_OUTPUT for the action to surface as outputs, and the action then
+# pushes E2E_SNAPSHOT_ADDRESSES_JSON to $GITHUB_ENV so downstream steps
+# inherit it.
+#
+# # Inputs (env vars, all set by the action with documented defaults)
+#
+#   IMAGE              full image reference to restore from.
+#   KURTOSIS_POS_REF   git ref of 0xPolygon/kurtosis-pos to clone for the
+#                      extract.sh / restore.sh helpers.
+#   OUT_DIR            directory the snapshot is extracted into. Resolved
+#                      to an absolute path before the kurtosis-pos scripts
+#                      run, since extract.sh's `cd` would mis-resolve a
+#                      relative path against its own working dir.
+#
+# # After this script exits 0
+#
+# `docker compose --file <OUT_DIR>/docker-compose.yaml ps` lists the running
+# devnet. The composite action's downstream steps tear it down via the
+# emitted compose_file_path output; nothing in this script registers a
+# trap for the compose stack itself.
+
+set -euo pipefail
+
+IMAGE="${IMAGE:?IMAGE must be set by the action}"
+KURTOSIS_POS_REF="${KURTOSIS_POS_REF:-main}"
+OUT_DIR="${OUT_DIR:-./tmp/e2e-snapshot}"
+WORK_DIR="$(mktemp -d)"
+
+cleanup() {
+  local exit_code=$?
+  if [ -n "${WORK_DIR:-}" ] && [ -d "$WORK_DIR" ]; then
+    rm -rf "$WORK_DIR"
+  fi
+  # state_hex_file / body_file are ~2 MB temp files created in step 6. The
+  # happy path rm's them inline, but curl or the JSON-RPC result check can
+  # exit non-zero before that — clean them here so no temp leaks on failure.
+  rm -f "${state_hex_file:-}" "${body_file:-}"
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+##############################################################################
+# 1. Pull the snapshot image
+##############################################################################
+echo "[restore] pulling ${IMAGE}"
+docker pull "$IMAGE"
+
+##############################################################################
+# 2. Clone kurtosis-pos for the extract.sh / restore.sh helpers
+##############################################################################
+# These two scripts (plus their log.sh dependency) are tiny and stable, but
+# they live upstream and we'd rather pin to a known kurtosis-pos commit than
+# vendor copies that silently drift from the snapshot they're paired with.
+echo "[restore] cloning kurtosis-pos@${KURTOSIS_POS_REF} into ${WORK_DIR}"
+git clone --depth 1 --branch "$KURTOSIS_POS_REF" \
+  https://github.com/0xPolygon/kurtosis-pos.git "$WORK_DIR"
+
+##############################################################################
+# 3. Extract volumes + docker-compose + addresses sidecar from the image
+##############################################################################
+# extract.sh creates a transient container from the image, copies /volumes
+# and /docker-compose.yaml out to OUT_DIR, then untars the volume archives.
+# It does NOT know about our addresses sidecar file, so we pull that out
+# ourselves with a second `docker create` + `docker cp`.
+mkdir -p "$OUT_DIR"
+# Resolve OUT_DIR to an absolute path BEFORE the outer subshell. Bash
+# evaluates `$(cd "$OUT_DIR" && pwd)` inside the outer `( cd ... )` with
+# the *modified* CWD, so a relative `OUT_DIR=./tmp/e2e-snapshot` resolved
+# against `$WORK_DIR/scripts/snapshot` and silently failed — extract.sh
+# then dumped files to its own default `./tmp` and downstream steps
+# couldn't find the docker-compose.
+OUT_DIR_ABS="$(cd "$OUT_DIR" && pwd)"
+echo "[restore] extracting ${IMAGE} -> ${OUT_DIR_ABS}"
+( cd "$WORK_DIR/scripts/snapshot" && bash ./extract.sh "$IMAGE" "$OUT_DIR_ABS" )
+
+ADDRS_FILE="${OUT_DIR_ABS}/e2e-snapshot-addresses.json"
+echo "[restore] extracting addresses sidecar -> ${ADDRS_FILE}"
+# `--entrypoint /bin/true` OVERRIDES any ENTRYPOINT the image declares; the
+# bare `docker create "$IMAGE" /bin/true` form only sets CMD, so an image with
+# an entrypoint would run `<entrypoint> /bin/true` instead and the create could
+# behave unexpectedly. We only need a stopped container to `docker cp` from.
+addr_extract_cid="$(docker create --entrypoint /bin/true "$IMAGE")"
+# Older snapshot images built before bake-addresses landed do not have this
+# file; tolerate that (the consumer suite then falls back to its kurtosis
+# CLI path or fails with a clear error).
+docker cp "${addr_extract_cid}:/e2e-snapshot-addresses.json" "$ADDRS_FILE" 2>/dev/null \
+  || echo "[restore] WARNING: image has no /e2e-snapshot-addresses.json — older snapshot?"
+docker rm "$addr_extract_cid" >/dev/null
+
+##############################################################################
+# 4. Patch anvil host-port mapping into the extracted docker-compose
+##############################################################################
+# kurtosis-pos's `snapshot.sh::configure_ports` only adds host port bindings
+# to services whose names match `^<enclave>-(el|cl|l2-el|l2-cl)-N-...`. With
+# `l1_backend: anvil`, the L1 EL service ends up named `pos-anvil` (no `el-N`
+# segment) and configure_ports skips it — so the published image's
+# docker-compose has anvil with no host port at all, and `localhost:8545`
+# isn't bound after `docker compose up`.
+#
+# Patch the missing port mapping in here before calling restore.sh so the
+# restored devnet exposes anvil's RPC at the same `8545:8545` mapping the
+# rest of the e2e suite hardcodes (`up.ts`'s `SNAPSHOT_L1_RPC_URL`).
+# Long-term fix lives upstream in kurtosis-pos's snapshot.sh; tracked as a
+# follow-up.
+COMPOSE_FILE="${OUT_DIR_ABS}/docker-compose.yaml"
+echo "[restore] adding 8545:8545 host-port to pos-anvil in ${COMPOSE_FILE}"
+python3 - "$COMPOSE_FILE" <<'PY'
+import sys
+import yaml
+
+path = sys.argv[1]
+with open(path) as fh:
+    doc = yaml.safe_load(fh)
+
+services = doc.get("services") or {}
+anvil_keys = [k for k in services if "anvil" in k]
+if not anvil_keys:
+    print("[restore] WARNING: no anvil service in docker-compose — snapshot may use a non-anvil L1", file=sys.stderr)
+else:
+    for k in anvil_keys:
+        services[k]["ports"] = ["8545:8545"]
+
+with open(path, "w") as fh:
+    yaml.safe_dump(doc, fh, default_flow_style=False, sort_keys=False)
+PY
+
+##############################################################################
+# 5. Restore docker volumes and bring the devnet up
+##############################################################################
+# restore.sh creates each named docker volume, untars the volume contents
+# back in, then runs `docker compose up --detach` against the (now anvil-
+# patched) docker-compose.yaml.
+#
+# Tear down any previous restore on this runner before starting fresh.
+# Upstream `restore.sh` is idempotent against named volumes (it tars
+# *into* an existing volume) and `docker compose up --detach` no-ops
+# against already-running containers — so calling restore on top of a
+# live devnet leaves the chain at whatever state the previous test
+# left it. The publisher's smoke step re-invokes this script mid-suite
+# to revert to the snapshot's chain state; without an explicit `down`
+# the revert silently doesn't happen.
+if docker compose --file "$COMPOSE_FILE" ps --quiet 2>/dev/null | grep -q .; then
+  echo "[restore] tearing down previous devnet before re-restoring"
+  docker compose --file "$COMPOSE_FILE" down --remove-orphans
+  # The compose's volumes are declared `external: true`, so
+  # `down --volumes` is a no-op against them. Wipe the named pos-*
+  # volumes explicitly so restore.sh's `tar xzf` lands in empty
+  # volumes — otherwise leftover files from the previous chain run
+  # mix with the snapshot's tarball contents and bor crashes on
+  # `Failed to truncate extra state histories`.
+  docker volume ls --filter 'name=^pos-' --format '{{.Name}}' \
+    | xargs -r docker volume rm
+fi
+
+echo "[restore] restoring volumes + starting devnet"
+( cd "$WORK_DIR/scripts/snapshot" && bash ./restore.sh "$OUT_DIR_ABS" )
+
+# Wait for L2 (bor) to bind 9545 — `docker compose up --wait` only
+# gates on heimdall's healthcheck (bor's depends_on), which doesn't
+# exercise bor's JSON-RPC. Without this poll, the cron-driven test's
+# bootIntegration races bor's startup and reads `ECONNREFUSED`.
+L2_RPC_URL="${L2_RPC_URL:-http://127.0.0.1:9545}"
+echo "[restore] waiting for L2 RPC at ${L2_RPC_URL}"
+deadline=$((SECONDS + 60))
+until curl -fsSL -X POST -H 'Content-Type: application/json' \
+        --data '{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}' \
+        "$L2_RPC_URL" >/dev/null 2>&1; do
+  if [ "$SECONDS" -gt "$deadline" ]; then
+    echo "[restore] ERROR: L2 RPC at ${L2_RPC_URL} did not respond within 60s — bor likely crashed at startup" >&2
+    docker compose --file "$COMPOSE_FILE" logs --tail=40 >&2 || true
+    exit 1
+  fi
+  sleep 1
+done
+
+##############################################################################
+# 6. Re-apply anvil state captured at snapshot time
+##############################################################################
+# The anvil container's startup args include `--load-state /opt/anvil/
+# genesis.json --dump-state /tmp/state_dump.json` (kurtosis-pos default).
+# That dump-state path is /tmp, which the snapshot doesn't capture, so on
+# restore anvil loads the bare genesis and every L1 contract is missing.
+#
+# `build-e2e-snapshot.sh` worked around this by writing
+# `anvil_dumpState`'s hex result into the anvil volume at
+# /opt/anvil/state_dump.hex BEFORE snapshot.sh ran. Read it back here via
+# `docker exec` and replay it via the `anvil_loadState` JSON-RPC, which
+# overlays the captured state onto the booted-from-genesis chain.
+ANVIL_RPC_URL="${ANVIL_RPC_URL:-http://127.0.0.1:8545}"
+echo "[restore] applying captured anvil state via ${ANVIL_RPC_URL}"
+deadline=$((SECONDS + 60))
+until curl -fsSL -X POST -H 'Content-Type: application/json' \
+        --data '{"jsonrpc":"2.0","method":"web3_clientVersion","id":1}' \
+        "$ANVIL_RPC_URL" >/dev/null 2>&1; do
+  if [ "$SECONDS" -gt "$deadline" ]; then
+    echo "[restore] ERROR: anvil RPC at ${ANVIL_RPC_URL} did not respond within 60s" >&2
+    exit 1
+  fi
+  sleep 1
+done
+ANVIL_CONTAINER="$(docker compose --file "$COMPOSE_FILE" ps --format '{{.Name}}' | grep '^pos-anvil$' | head -1)"
+if [ -z "$ANVIL_CONTAINER" ]; then
+  echo "[restore] ERROR: pos-anvil container not running after compose up" >&2
+  exit 1
+fi
+# Stream the hex to a local tempfile, then assemble the JSON-RPC body
+# inline. The hex is ~2 MB; passing it as a command-line argument
+# exceeds ARG_MAX (~128 KB on Linux), so everything that touches the
+# blob has to go through file/pipe redirection.
+state_hex_file="$(mktemp)"
+docker exec "$ANVIL_CONTAINER" cat /opt/anvil/state_dump.hex > "$state_hex_file" 2>/dev/null || true
+state_hex_bytes="$(wc -c < "$state_hex_file")"
+if [ "$state_hex_bytes" -lt 100 ]; then
+  echo "[restore] WARNING: pos-anvil:/opt/anvil/state_dump.hex missing or empty (${state_hex_bytes} bytes) — older snapshot?" >&2
+  rm -f "$state_hex_file"
+else
+  body_file="$(mktemp)"
+  {
+    printf '{"jsonrpc":"2.0","method":"anvil_loadState","params":["'
+    cat "$state_hex_file"
+    printf '"],"id":1}'
+  } > "$body_file"
+  rm -f "$state_hex_file"
+  load_response="$(curl -fsSL -X POST -H 'Content-Type: application/json' \
+    --data-binary "@${body_file}" "$ANVIL_RPC_URL")"
+  rm -f "$body_file"
+  if ! printf '%s' "$load_response" | python3 -c 'import json,sys; r=json.load(sys.stdin); sys.exit(0 if r.get("result") is True else 1)'; then
+    echo "[restore] ERROR: anvil_loadState rejected the captured state: $load_response" >&2
+    exit 1
+  fi
+  echo "[restore] anvil state restored (${state_hex_bytes} bytes)"
+fi
+
+##############################################################################
+# 7. Surface output paths
+##############################################################################
+{
+  echo "addresses_json_path=${ADDRS_FILE}"
+  echo "compose_file_path=${COMPOSE_FILE}"
+} >> "$GITHUB_OUTPUT"
+
+echo ""
+echo "[restore] done. devnet is running."
+echo "[restore]   compose file:  ${COMPOSE_FILE}"
+echo "[restore]   addresses:     ${ADDRS_FILE}"
+echo "[restore]   list services: docker compose --file ${COMPOSE_FILE} ps"
+echo "[restore]   tear down:     docker compose --file ${COMPOSE_FILE} down --volumes"

--- a/.github/workflows/apps-e2e-trigger.yml
+++ b/.github/workflows/apps-e2e-trigger.yml
@@ -1,0 +1,69 @@
+name: e2e
+
+# Canonical e2e trigger. Copy verbatim into a consumer repo's
+# `.github/workflows/e2e-trigger.yml` and adjust only the inputs the
+# consumer needs to override (e.g. `e2e_command`, `cold_start_args_file`).
+# All shared logic lives in `apps-e2e.yml`.
+#
+# Two paths:
+#
+#   - Snapshot mode (`use_snapshot=true`, default): pull the published
+#     snapshot image and restore via the e2e-snapshot-restore composite.
+#     ~30s.
+#   - Cold-start mode (`use_snapshot=false`): clone kurtosis-pos at
+#     `kurtosis_pos_ref` and run the enclave from source. ~10m. Use only
+#     when iterating on a kurtosis-pos branch that hasn't been
+#     snapshotted yet.
+
+on:
+  workflow_dispatch:
+    inputs:
+      use_snapshot:
+        description: 'Restore from the published snapshot image (false = cold-start)'
+        type: boolean
+        required: false
+        default: true
+      kurtosis_pos_ref:
+        description: 'Cold-start mode: git ref of 0xPolygon/kurtosis-pos to clone'
+        required: false
+        default: main
+  # Opt-in per PR via the `run-e2e` label. Subsequent pushes to a labelled
+  # PR re-run automatically.
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+# One enclave per branch. Two parallel runs would exhaust Docker
+# resources on the runner.
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # Mirrors the called workflow's `packages: read`. GitHub fails the
+  # workflow at startup if the trigger's permissions are not a superset
+  # of the called workflow's.
+  packages: read
+
+jobs:
+  e2e:
+    # `github.repository != '0xPolygon/pipelines'` keeps this template
+    # inert in the pipelines repo itself — pipelines has no `pnpm run e2e`,
+    # so a `run-e2e` label or a dispatch here would spawn an apps-e2e@main
+    # run with nothing to execute. The guard is a no-op in any consumer
+    # repo (its name is never `0xPolygon/pipelines`), so copy it verbatim.
+    # Beyond that: skip PRs without the label; workflow_dispatch always runs.
+    if: >-
+      github.repository != '0xPolygon/pipelines' &&
+      (github.event_name != 'pull_request' ||
+       contains(github.event.pull_request.labels.*.name, 'run-e2e'))
+    uses: 0xPolygon/pipelines/.github/workflows/apps-e2e.yml@main
+    with:
+      # GH Actions' `==`/`!=` use loose equality where `null == false`
+      # evaluates to true — so a `inputs.use_snapshot == null` check
+      # also matches an explicit boolean false. Stringify via toJSON
+      # first to distinguish: toJSON(null) → "null", toJSON(false) →
+      # "false", toJSON(true) → "true". Default everything except an
+      # explicit "false" to true (snapshot is the strong default).
+      use_snapshot: ${{ fromJSON(toJSON(inputs.use_snapshot) == 'false' && 'false' || 'true') }}
+      kurtosis_pos_ref: ${{ inputs.kurtosis_pos_ref || 'main' }}

--- a/.github/workflows/apps-e2e.yml
+++ b/.github/workflows/apps-e2e.yml
@@ -1,0 +1,187 @@
+name: E2E (kurtosis devnet)
+
+# Reusable e2e workflow for repos that integrate against a kurtosis-pos
+# devnet. Two paths:
+#
+#   - Snapshot mode (default): pull the published snapshot image and
+#     restore via the e2e-snapshot-restore composite. Wall-time ~30s.
+#     Use this for any consumer testing against kurtosis-pos main.
+#   - Cold-start mode: clone kurtosis-pos at `kurtosis_pos_ref` and run
+#     the enclave from source. Wall-time ~10min. Reach for this only
+#     when iterating on a kurtosis-pos branch that hasn't been
+#     snapshotted yet.
+#
+# Trigger files in consumer repos are thin: they specify the event
+# (workflow_dispatch + pull_request labeled) and forward inputs. If the
+# consumer's snapshot image is in a private registry its own token can't
+# reach, the trigger passes REGISTRY_USERNAME / REGISTRY_PASSWORD by name
+# under `secrets:` (never `secrets: inherit` — see Team Standards). See
+# apps-e2e-trigger.yml in this repo for the canonical example.
+
+on:
+  workflow_call:
+    inputs:
+      use_snapshot:
+        description: >
+          Restore from the published snapshot image (false = cold-start
+          kurtosis from source).
+        type: boolean
+        required: false
+        default: true
+      kurtosis_pos_ref:
+        description: >
+          Cold-start mode: git ref of 0xPolygon/kurtosis-pos to clone.
+          Snapshot mode: passed to the extract.sh / restore.sh helper
+          clone — should match the ref the snapshot was built with.
+        type: string
+        required: false
+        default: main
+      snapshot_image:
+        description: >
+          Snapshot image reference (full registry/repo:tag). Default
+          points at the lst-api-published snapshot. Override only when
+          the consumer publishes its own snapshot.
+        type: string
+        required: false
+        default: ghcr.io/0xpolygon/lst-api-e2e-snapshot:latest
+      cold_start_args_file:
+        description: >
+          Cold-start mode: path to the kurtosis args file in the
+          consumer's checkout (relative to GITHUB_WORKSPACE).
+        type: string
+        required: false
+        default: kurtosis-params.yml
+      e2e_command:
+        description: >
+          Shell command run by the suite step. Default `pnpm run e2e`
+          assumes the consumer's package.json wires its e2e entrypoint
+          there. Wrap any pre-commands with && (e.g. starting a Firestore
+          emulator) when needed; vitest globalSetup handlers are usually
+          the cleaner home for those.
+
+
+          ADAPTER CONTRACT — the suite this command runs must read the
+          devnet's connection details from the environment this workflow
+          sets, and the two modes expose them differently:
+
+            - Snapshot mode: contract addresses are in the JSON file at
+              `$E2E_SNAPSHOT_ADDRESSES_JSON` (exported by the restore
+              composite); RPCs are at the fixed host ports
+              `127.0.0.1:8545` (L1) / `127.0.0.1:9545` (L2).
+            - Cold-start mode: no addresses file. `$E2E_KURTOSIS_ENCLAVE`
+              (default `pos`) names the running enclave; query it via the
+              kurtosis CLI for addresses and dynamically-mapped ports.
+
+          A consumer therefore needs a dual-path adapter — see lst-api's
+          `packages/e2e/scripts/up.ts` for the reference. This is real
+          porting work, not a thin trigger.
+
+
+          SECRETS — the suite step runs with only the registry secrets
+          (below) and whatever `GITHUB_TOKEN` provides. There is no
+          generic mechanism to inject arbitrary consumer secrets into the
+          suite (`secrets: inherit` is prohibited by Team Standards). A
+          consumer needing, e.g., an RPC token must have it added as a
+          named secret on this workflow — open a PR here when that lands.
+        type: string
+        required: false
+        default: pnpm run e2e
+      timeout_minutes:
+        description: >
+          Job timeout. Default 45 covers cold-start (~10m bring-up +
+          ~10m suite + headroom); snapshot runs typically finish under 8.
+        type: number
+        required: false
+        default: 45
+    secrets:
+      REGISTRY_USERNAME:
+        description: >
+          Username for the snapshot-image registry login. Optional —
+          omit to use the workflow actor + GITHUB_TOKEN, which works for
+          same-org GHCR pulls. A cross-org consumer (e.g. matic.js in
+          maticnetwork pulling the 0xpolygon snapshot) passes its own
+          credentials here so the private package resolves.
+        required: false
+      REGISTRY_PASSWORD:
+        description: >
+          Token for the snapshot-image registry login. Pair with
+          REGISTRY_USERNAME. Optional; defaults to GITHUB_TOKEN.
+        required: false
+
+# `packages: read` lets the GITHUB_TOKEN pull from GHCR in snapshot mode;
+# ignored by cold-start runs that never touch the registry.
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  e2e:
+    name: e2e (kurtosis devnet)
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    env:
+      # Centralise the snapshot/cold-start switch as an env var so every
+      # downstream step references a single value. Snapshot is the
+      # default; only an explicit boolean false flips us to cold-start.
+      #
+      # GH Actions' `==`/`!=` use loose equality where `null == false`
+      # evaluates to true — so the obvious `inputs.use_snapshot == false`
+      # check would also fire on null and silently drop pull_request
+      # runs (which have null inputs) into cold-start. Stringify via
+      # toJSON first: toJSON(null) → "null", toJSON(false) → "false",
+      # toJSON(true) → "true". String comparison is unambiguous.
+      E2E_USE_SNAPSHOT: ${{ toJSON(inputs.use_snapshot) == 'false' && '0' || '1' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Restore from snapshot
+        if: env.E2E_USE_SNAPSHOT == '1'
+        id: snapshot
+        uses: 0xPolygon/pipelines/.github/actions/e2e-snapshot-restore@main
+        with:
+          image: ${{ inputs.snapshot_image }}
+          kurtosis_pos_ref: ${{ inputs.kurtosis_pos_ref }}
+          # Fall back to the workflow actor + GITHUB_TOKEN when the caller
+          # passes no registry secrets — preserves the same-org GHCR pull
+          # the composite defaults to. A cross-org caller supplies its own.
+          registry_username: ${{ secrets.REGISTRY_USERNAME || github.actor }}
+          registry_password: ${{ secrets.REGISTRY_PASSWORD || github.token }}
+
+      - name: Cold-start kurtosis
+        if: env.E2E_USE_SNAPSHOT == '0'
+        uses: 0xPolygon/pipelines/.github/actions/e2e-cold-start@main
+        with:
+          kurtosis_pos_ref: ${{ inputs.kurtosis_pos_ref }}
+          args_file: ${{ inputs.cold_start_args_file }}
+
+      - name: Run e2e suite
+        env:
+          E2E_COMMAND: ${{ inputs.e2e_command }}
+        run: bash -c "$E2E_COMMAND"
+
+      # On failure, capture devnet state for post-mortem. Logic lives in
+      # the e2e-dump composite (bundled script) rather than inline here —
+      # keeps this YAML thin and the shell locally runnable.
+      - name: Dump devnet on failure
+        if: failure()
+        uses: 0xPolygon/pipelines/.github/actions/e2e-dump@main
+        with:
+          use_snapshot: ${{ env.E2E_USE_SNAPSHOT }}
+          compose_file: ${{ steps.snapshot.outputs.compose_file_path }}
+
+      - name: Upload devnet dump
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: devnet-dump-${{ github.run_id }}
+          path: /tmp/devnet-dump
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ in its own separate GitHub Actions job with its own runner.
 | `apps-slack-merge-notify.yml` | Posts a Slack Block Kit message when a PR is merged | `SLACK_WEBHOOK_URL` |
 | `apps-claude-code-review.yml` | Automated Claude Code PR review | `CLAUDE_API_KEY` |
 | `apps-claude.yml` | Interactive Claude Code agent (triggered by @claude mentions) | `CLAUDE_API_KEY` |
+| `apps-e2e.yml` | Kurtosis-pos devnet e2e harness (snapshot restore + cold-start), with on-failure devnet dump as artefact | _(none)_ |
 
 Trigger file examples for each of the above live alongside them as
 `apps-*-trigger.yml` and also serve as canonical templates for consuming
@@ -57,6 +58,9 @@ system state automatically.
 | `actions/npm-release` | Publish, tag, and release post-changesets merge | No — bash script |
 | `actions/slack-notify` | Post Slack Block Kit message from `pr.json` | Yes — ncc bundle |
 | `actions/upsert-changeset-comment` | Post or remove changeset nag comment on a PR | Yes — ncc bundle |
+| `actions/e2e-snapshot-restore` | Restore a kurtosis-pos devnet from a published GHCR snapshot image | No — pure shell |
+| `actions/e2e-cold-start` | Bring up a kurtosis-pos devnet from source | No — pure shell |
+| `actions/e2e-dump` | Capture devnet state (compose logs or kurtosis enclave) on e2e failure | No — pure shell |
 
 ### `actions/ci`
 
@@ -183,6 +187,18 @@ respectively. Both contain logic that runs across repository boundaries inside a
 reusable workflow context, so they must be compiled ncc bundles (raw
 `.github/scripts/` files are not accessible in the calling repo's workspace).
 See [Adding a new composite action with compiled dist](#adding-a-new-composite-action-with-compiled-dist).
+
+### `actions/e2e-snapshot-restore`, `actions/e2e-cold-start`, `actions/e2e-dump`
+
+Used by `apps-e2e.yml`. Each composite action ships its bash helper next to
+its `action.yml` and references it via `${{ github.action_path }}`, so no ncc
+bundle is needed — composite actions can read sibling files even when called
+cross-repo. (A reusable workflow can't run a repo-local `.github/scripts/`
+helper cross-repo for the same reason, which is why the on-failure dump is a
+composite — `e2e-dump` — rather than an inline `run:` block or a scripts
+file.) Consumers should call `apps-e2e.yml` rather than the composites
+directly; the workflow handles the snapshot/cold-start switch and on-failure
+devnet artefact upload.
 
 ---
 


### PR DESCRIPTION
## Summary

Consumer-side kurtosis-pos e2e harness, factored into `0xPolygon/pipelines` so adopters call one shared implementation instead of vendoring copies that drift. lst-api migrates onto it in a stacked PR (0xPolygon/lst-api#125); matic.js and proof-generation-api are the next candidates.

- **`apps-e2e.yml`** — reusable workflow. Snapshot mode (default, ~30s) restores a published GHCR image via the `e2e-snapshot-restore` composite; cold-start mode (~10m) runs kurtosis from source via `e2e-cold-start` for kurtosis-pos refs that haven't been snapshotted. Runs the consumer's `e2e_command`, dumps devnet state on failure, uploads a 7-day artefact. Optional `REGISTRY_USERNAME` / `REGISTRY_PASSWORD` secrets let a cross-org consumer pull a private snapshot with its own credentials, falling back to the workflow actor + `GITHUB_TOKEN` when unset.
- **`actions/e2e-snapshot-restore`** — pull + restore a snapshot image (extract volumes, patch the `pos-anvil` host port, replay anvil state). Bundles its `restore.sh` next to `action.yml`, referenced via `${{ github.action_path }}`.
- **`actions/e2e-cold-start`** — install kurtosis-cli, scale EL resource limits down to fit `ubuntu-latest`, run the enclave from source. Exports `E2E_KURTOSIS_ENCLAVE` so a consumer can write a single env-driven adapter across both modes.
- **`actions/e2e-dump`** — capture devnet state on failure (compose logs or kurtosis enclave dump). A composite rather than an inline `run:` block or a `.github/scripts/` helper, because a reusable workflow can't reach a repo-local script when it runs in a consumer's checkout.
- **`apps-e2e-trigger.yml`** — canonical thin trigger for consumers to copy, guarded against firing on pipelines' own PRs.
- **README** — workflow + composite tables and usage notes.

## `use_snapshot` boolean handling

The snapshot/cold-start switch resolves via `toJSON(inputs.use_snapshot) == 'false'`. GitHub Actions' `==`/`!=` use loose equality where `null == false` evaluates to true, so a naive `inputs.use_snapshot == false` would also match the null inputs that `pull_request` events carry and silently drop label-triggered PR runs into the slow cold-start path. Stringifying via `toJSON` first (`"null"` / `"false"` / `"true"`) makes the comparison unambiguous; snapshot stays the strong default and only an explicit boolean `false` flips to cold-start.

## Review feedback (all resolved)

Addressing the API review on this PR plus the automated review:

- Trigger guarded with `github.repository != '0xPolygon/pipelines'` so a `run-e2e` label here doesn't spawn a run with no `pnpm run e2e`.
- `e2e-snapshot-restore` uses `docker create --entrypoint /bin/true` so the addresses-sidecar extraction overrides any `ENTRYPOINT` a future snapshot declares.
- Cold-start verifies the EL resource scale-down actually applied (greps the override marker, fails loud) rather than silently OOM-killing on a ref that renamed the vars.
- Temp files in the anvil-state replay fold into the cleanup trap (no leak on a `curl` failure).
- Registry secrets surfaced + forwarded (cross-org private-snapshot pull).
- `secrets: inherit` recommendation removed (prohibited by Team Standards); the dual-path adapter contract and the named-secrets-only limitation are documented on the `e2e_command` input.

Deferred as design polish (tracked for follow-up, not blocking adoption): `runner` / `checkout_fetch_depth` inputs, `jq`-over-`python3`, install-after-composite ordering, enclave-name parameterisation, `required` `snapshot_image`. Generic suite-secret injection stays out — named secrets only.

## Out of scope

The snapshot publisher stays in lst-api against its GHCR namespace; moving and renaming it is a separate refactor once a second consumer hits a publisher-side bug.

## Validation

Validated cross-repo against lst-api#125 before this branch was cleaned up:

- [x] Snapshot mode via `run-e2e` label — restore + suite green end-to-end.
- [x] Cold-start mode via dispatch — `e2e-cold-start` brought kurtosis up cleanly; the suite failure there is the documented pre-block-256 `eth_getLogs` limitation (consumer-side), not the workflow.
- [x] Failure path — on-failure dump produced a `devnet-dump-<run-id>` artefact.

Cross-repo refs were pinned to this feature branch during validation, then reverted to `@main`. History has since been squashed to a single commit on top of current `main`.
